### PR TITLE
fix native auth whitelister check

### DIFF
--- a/api/middleware/nativeAuthWhitelistHandler.go
+++ b/api/middleware/nativeAuthWhitelistHandler.go
@@ -56,7 +56,6 @@ func extractBaseRoutePath(path string) string {
 func (handler *nativeAuthWhitelistHandler) IsWhitelisted(route string) bool {
 	baseRoute := extractBaseRoutePath(route)
 	_, found := handler.whitelistedRoutesMap[baseRoute]
-	log.Error("adas", "map", handler.whitelistedRoutesMap, "bb", baseRoute)
 	return found
 }
 

--- a/api/middleware/nativeAuthWhitelistHandler.go
+++ b/api/middleware/nativeAuthWhitelistHandler.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/multiversx/mx-multi-factor-auth-go-service/config"
 )
@@ -20,7 +21,8 @@ func NewNativeAuthWhitelistHandler(apiPackages map[string]config.APIPackageConfi
 		for _, route := range groupCfg.Routes {
 			if !route.Auth {
 				fullPath := fmt.Sprintf("%s%s", groupPath, route.Name)
-				whitelistedRoutes[fullPath] = struct{}{}
+				basePath := trimPathPlaceholder(fullPath)
+				whitelistedRoutes[basePath] = struct{}{}
 			}
 		}
 	}
@@ -31,9 +33,30 @@ func NewNativeAuthWhitelistHandler(apiPackages map[string]config.APIPackageConfi
 	}
 }
 
+func trimPathPlaceholder(path string) string {
+	parts := strings.Split(path, ":")
+	if len(parts) > 0 {
+		return "/" + strings.Trim(parts[0], "/")
+	}
+
+	return path
+}
+
+func extractBaseRoutePath(path string) string {
+	parts := strings.Split(path, "/")
+
+	if len(parts) > 2 {
+		return "/" + parts[1] + "/" + parts[2] // group and base path
+	}
+
+	return path
+}
+
 // IsWhitelisted returns true if the provided route is whitelisted for native authentication
 func (handler *nativeAuthWhitelistHandler) IsWhitelisted(route string) bool {
-	_, found := handler.whitelistedRoutesMap[route]
+	baseRoute := extractBaseRoutePath(route)
+	_, found := handler.whitelistedRoutesMap[baseRoute]
+	log.Error("adas", "map", handler.whitelistedRoutesMap, "bb", baseRoute)
 	return found
 }
 

--- a/api/middleware/nativeAuthWhitelistHandler_test.go
+++ b/api/middleware/nativeAuthWhitelistHandler_test.go
@@ -23,6 +23,11 @@ func TestNativeAuthWhitelistHandler(t *testing.T) {
 					Open: true,
 					Auth: false,
 				},
+				{
+					Name: "/user-status/:address",
+					Open: true,
+					Auth: false,
+				},
 			},
 		},
 		"status": {
@@ -43,9 +48,13 @@ func TestNativeAuthWhitelistHandler(t *testing.T) {
 	require.True(t, handler.IsWhitelisted("/guardian"))
 	require.True(t, handler.IsWhitelisted("/status"))
 	require.True(t, handler.IsWhitelisted("/log"))
+	require.True(t, handler.IsWhitelisted("/guardian/user-status/erd1"))
+	require.True(t, handler.IsWhitelisted("/guardian/user-status"))
+	require.True(t, handler.IsWhitelisted("/guardian/user-status/"))
 	require.False(t, handler.IsWhitelisted("/guardian/register"))
 	require.False(t, handler.IsWhitelisted("guardian/sign-transaction"))
 	require.False(t, handler.IsWhitelisted("/sign-transaction"))
+	require.False(t, handler.IsWhitelisted("guardian/user-status/erd1"))
 	require.False(t, handler.IsWhitelisted("guardian"))
 	require.False(t, handler.IsWhitelisted(""))
 }


### PR DESCRIPTION
Api path with placeholder in `api.toml` config file were not managed properly in native auth whitelister.
- so placeholder has to be excluded from path check
- check updated so that only the group and bash path is considered